### PR TITLE
Test/trino query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ buildNumber.properties
 .mvn/timing.properties
 # https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
+
+# Test config
+config.properties

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 
 # Test config
-config.properties
+test-settings.properties

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Current File",
+            "request": "launch",
+            "mainClass": "${file}"
+        },
+        {
+            "type": "java", 
+            "name": "Debug (Attach)",
+            "projectName": "TRINO-JTOPEN",
+            "request": "attach",
+            "hostName": "localhost",
+            "port": 8000
+      }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
     <dependencies>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-jdbc</artifactId>
+            <version>${dep.trino.version}</version>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${dep.guava.version}</version>

--- a/src/test/java/io/trino/plugin/jtopen/TestJTOpenPlugin.java
+++ b/src/test/java/io/trino/plugin/jtopen/TestJTOpenPlugin.java
@@ -22,14 +22,59 @@ import org.junit.jupiter.api.Test;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestJTOpenPlugin
-{
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+public class TestJTOpenPlugin {
     @Test
-    public void testCreateConnector()
-    {
+    public void testCreateConnector() {
         Plugin plugin = new JTOpenPlugin();
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         assertEquals(factory.getName(), "jtopen");
         factory.create("test", ImmutableMap.of("connection-url", "jdbc:as400:test"), new TestingConnectorContext());
+    }
+
+    @Test
+    public void testQuery() throws IOException, ClassNotFoundException {
+        // Expected data
+        List<String> expectedColumnNames = List.of("id", "first_name", "last_name", "email");
+
+        // Get trino jdbc url
+        Properties prop = new Properties();
+        FileInputStream ip = new FileInputStream("config.properties");
+        prop.load(ip);
+        String url = prop.getProperty("db.url");
+
+        // Use Trino Driver and establish connection
+        Class.forName("io.trino.jdbc.TrinoDriver");
+
+        String query = "SELECT * FROM qgpl.customers";
+
+        try (
+            Connection connection = DriverManager.getConnection(url);
+            Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery(query);
+            ) 
+        {
+            ResultSetMetaData rsMetadata = resultSet.getMetaData();
+
+            // Verify correct column names
+            List<String> actualColumnNames = new ArrayList<>();
+            for (int i = 1; i <= rsMetadata.getColumnCount(); i++) {
+                actualColumnNames.add(rsMetadata.getColumnName(0));
+            }
+            assertEquals(expectedColumnNames, actualColumnNames);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/test/java/io/trino/plugin/jtopen/TestJTOpenPlugin.java
+++ b/src/test/java/io/trino/plugin/jtopen/TestJTOpenPlugin.java
@@ -20,6 +20,7 @@ import io.trino.testing.TestingConnectorContext;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.FileInputStream;
@@ -46,18 +47,18 @@ public class TestJTOpenPlugin {
     @Test
     public void testQuery() throws IOException, ClassNotFoundException {
         // Expected data
-        List<String> expectedColumnNames = List.of("id", "first_name", "last_name", "email");
+        List<String> expectedColumnNames = List.of("empno", "firstnme", "midinit", "lastname", "workdept", "phoneno", "hiredate", "job", "edlevel", "sex", "birthdate", "salary", "bonus", "comm");
 
         // Get trino jdbc url
         Properties prop = new Properties();
-        FileInputStream ip = new FileInputStream("config.properties");
+        FileInputStream ip = new FileInputStream("test-settings.properties");
         prop.load(ip);
         String url = prop.getProperty("db.url");
 
         // Use Trino Driver and establish connection
         Class.forName("io.trino.jdbc.TrinoDriver");
 
-        String query = "SELECT * FROM qgpl.customers";
+        String query = "SELECT * FROM qgpl.emptest";
 
         try (
             Connection connection = DriverManager.getConnection(url);
@@ -70,11 +71,12 @@ public class TestJTOpenPlugin {
             // Verify correct column names
             List<String> actualColumnNames = new ArrayList<>();
             for (int i = 1; i <= rsMetadata.getColumnCount(); i++) {
-                actualColumnNames.add(rsMetadata.getColumnName(0));
+                actualColumnNames.add(rsMetadata.getColumnName(i));
             }
             assertEquals(expectedColumnNames, actualColumnNames);
         } catch (SQLException e) {
             e.printStackTrace();
+            fail();
         }
     }
 }


### PR DESCRIPTION
Creates simple test case which runs against a table, emptest, and verifies the column names.
The connection url is set in the `test-settings.properties` filename, which looks like the following.

`db.url=jdbc:trino://mymachine`